### PR TITLE
exclude.some instead of exclude.every

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -21,7 +21,7 @@ export function flattenStories(stories: StoryKind[]) {
 export function filterStories(flatStories: Story[], include: string[], exclude: string[]): Story[] {
   const conbined = flatStories.map(s => ({ ...s, name: s.kind + "/" + s.story }));
   const included = include.length ? conbined.filter(s => include.some(rule => minimatch(s.name, rule))) : conbined;
-  const excluded = exclude.length ? included.filter(s => !exclude.every(rule => minimatch(s.name, rule))) : included;
+  const excluded = exclude.length ? included.filter(s => !exclude.some(rule => minimatch(s.name, rule))) : included;
   return excluded;
 }
 


### PR DESCRIPTION
Correct behaviour of exclude command line option. Now only some of the items have to match and not all of them.