### PR TITLE
Use the CLI-provided viewport size by default in managed mode

### DIFF
--- a/src/client/default-screenshot-options.ts
+++ b/src/client/default-screenshot-options.ts
@@ -4,10 +4,6 @@ export const defaultScreenshotOptions = {
   delay: 0,
   waitImages: true,
   waitFor: "",
-  viewport: {
-    width: 800,
-    height: 600,
-  },
   fullPage: true,
   skip: false,
 } as ScreenShotOptions;

--- a/src/node/browser.ts
+++ b/src/node/browser.ts
@@ -329,6 +329,8 @@ $doc.body.appendChild($style);
       if (!opt || opt.skip) {
         const elapsedTime = Date.now() - this.processStartTime;
         return { ...this.currentStory, buffer: null, elapsedTime };
+      } else if (!opt.viewport) {
+        opt.viewport = this.opt.defaultViewport;
       }
     }
     const succeeded = await this.setViewport(opt);


### PR DESCRIPTION
This still allows individual stories to set a different size with withScreenshot(), but otherwise it will use the viewport size provided via the CLI instead of forcing it to 800x600.

This fixes #21.